### PR TITLE
Add Dockerfile for image based on Apache Tomcat

### DIFF
--- a/docker/Adempiere.properties
+++ b/docker/Adempiere.properties
@@ -1,0 +1,33 @@
+#Adempiere
+Warehouse=xyz*
+WarningD=Einstellungen_nicht_aendern,_da_diese_undokumentierte_Nebenwirkungen_haben.
+Warning=Do_not_change_any_of_the_data_as_they_will_have_undocumented_side_effects.
+Organization=xyz*
+UITheme=xyzAdempiere Theme
+StorePassword=xyzY
+AutoCommit=xyzY
+Printer=xyz
+ShowAcct=xyzY
+Language=xyzEnglish
+TraceFile=xyzN
+CacheWindow=xyzY
+PrintPreview=xyzN
+ValidateConnectionOnStartup=xyzN
+UILookFeel=xyzAdempiere
+Client=xyzGardenWorld
+ShowTrl=xyzN
+TempDir=xyz/tmp
+ApplicationPassword=xyzGardenAdmin
+AutoNew=xyzN
+ApplicationUserID=xyzGardenAdmin
+LoadTabMetaDataBackground=xyzN
+SingleInstancePerWindow=xyzN
+Connection=xyzCConnection[name\=localhost{localhost-adempiere},AppsHost\=localhost,AppsPort\=0,type\=PostgreSQL,DBhost\=@ADEMPIERE_DB_SERVER@,DBport\=@ADEMPIERE_DB_PORT@,DBname\=@ADEMPIERE_DB_NAME@,BQ\=false,FW\=false,FWhost\=,FWport\=0,UID\=@ADEMPIERE_DB_USER@,PWD\=@ADEMPIERE_DB_PASSWORD@]
+Charset=xyzUTF-8
+OpenWindowMaximized=xyzN
+Role=xyzGardenWorld Admin
+AutoLogin=xyzN
+ShowAdvanced=xyzY
+AdempiereSys=xyzN
+TraceLevel=xyzWARNING
+LogMigrationScript=xyzN

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,34 @@
+# How to build docker images
+
+## Clean the project 
+```
+gradle clean 
+
+```
+
+## Create Release
+```
+gradle createRelease 
+
+```
+
+##Build With Apache Tomcat 
+```
+docker build -t adempiere-zk-tomcat -f docker/tomcat/Dockerfile .
+```
+
+## Run a Container
+```
+docker run -d -e "ADEMPIERE_DB_SERVER=database-server" -e "ADEMPIERE_DB_PORT=5432" adempiere-zk-tomcat
+```
+
+
+## Environment variables
+- `ADEMPIERE_DB_TYPE`: Database Type (Supported Oracle, PostgreSQL and MariaDB). Default **PostgreSQL**
+- `ADEMPIERE_DB_SERVER`: Hostname for PostgreSQL server. Default: **localhost**
+- `ADEMPIERE_DB_PORT`: Port used by PostgreSQL server. Default: **5432**
+- `ADEMPIERE_DB_NAME`: Database name that Adempiere will use to connect with the database. Default: **adempiere**
+- `ADEMPIERE_DB_USER`: Database user that Adempiere will use to connect with the database. Default: **adempiere**
+- `ADEMPIERE_DB_PASSWORD`: Database password that Adempiere will use to connect with the database. Default: **adempiere**
+- `ADEMPIERE_JAVA_OPTIONS`:  Additional java options to execute application. Default: **-Xms128m -Xmx1024m**
+- `ADEMPIERE_HOME`:  Directory of application. Default: **/opt/Adempiere** 

--- a/docker/tomcat/Dockerfile
+++ b/docker/tomcat/Dockerfile
@@ -1,0 +1,22 @@
+FROM tomcat:9.0.72-jdk11-temurin
+LABEL manteiner=cparada@erpya.com
+	
+ENV ADEMPIERE_HOME="/opt/Adempiere" \
+	ADEMPIERE_DB_USER="adempiere" \
+	ADEMPIERE_DB_PASSWORD="adempiere" \
+	ADEMPIERE_JAVA_OPTIONS="-Xms64M -Xmx1512M" \
+	ADEMPIERE_DB_TYPE="PostgreSQL" \
+	ADEMPIERE_DB_SERVER="localhost" \
+	ADEMPIERE_DB_NAME="adempiere" \
+	ADEMPIERE_DB_PORT="5432" 
+
+COPY docker/Adempiere.properties $ADEMPIERE_HOME/
+COPY docker/tomcat/settings/*.xml $CATALINA_HOME/conf
+COPY docker/tomcat/settings/setenv.sh $CATALINA_HOME/bin
+COPY build/libs/zk-ui.war $CATALINA_HOME/webapps/webui.war
+COPY build/libs/zk-ui.jar $CATALINA_HOME/lib
+COPY build/distributions/zk-ui.tar $CATALINA_HOME/lib
+
+RUN cd lib && \
+	tar -xvf zk-ui.tar zk-ui/lib --transform='s/.*\///' && \
+	rm -R lib zk-ui.tar

--- a/docker/tomcat/settings/context.xml
+++ b/docker/tomcat/settings/context.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<!-- The contents of this file will be loaded for each web application -->
+<Context>
+
+    <!-- Default set of monitored resources. If one of these changes, the    -->
+    <!-- web application will be reloaded.                                   -->
+    <WatchedResource>WEB-INF/web.xml</WatchedResource>
+    <WatchedResource>WEB-INF/tomcat-web.xml</WatchedResource>
+    <WatchedResource>${catalina.base}/conf/web.xml</WatchedResource>
+
+    <!-- Uncomment this to disable session persistence across Tomcat restarts -->
+    <!--
+    <Manager pathname="" />
+    -->
+    
+    <JarScanner scanManifest="false"/>
+    
+    <ResourceLink name="java/AdempiereDS"
+                  global="java/AdempiereDS"
+                  auth="Container"
+                  type="javax.sql.DataSource" />
+
+    <ResourceLink name="java/AdempiereSRDS"
+                  global="java/AdempiereSRDS"
+                  auth="Container"
+                  type="javax.sql.DataSource" />
+
+</Context>

--- a/docker/tomcat/settings/server.xml
+++ b/docker/tomcat/settings/server.xml
@@ -1,0 +1,216 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<!-- Note:  A "Server" is not itself a "Container", so you may not
+     define subcomponents such as "Valves" at this level.
+     Documentation at /docs/config/server.html
+ -->
+<Server port="8005" shutdown="SHUTDOWN">
+  <Listener className="org.apache.catalina.startup.VersionLoggerListener" />
+  <!-- Security listener. Documentation at /docs/config/listeners.html
+  <Listener className="org.apache.catalina.security.SecurityListener" />
+  -->
+  <!-- APR library loader. Documentation at /docs/apr.html -->
+  <Listener className="org.apache.catalina.core.AprLifecycleListener" SSLEngine="on" />
+  <!-- Prevent memory leaks due to use of particular java/javax APIs-->
+  <Listener className="org.apache.catalina.core.JreMemoryLeakPreventionListener" />
+  <Listener className="org.apache.catalina.mbeans.GlobalResourcesLifecycleListener" />
+  <Listener className="org.apache.catalina.core.ThreadLocalLeakPreventionListener" />
+
+  <!-- Global JNDI resources
+       Documentation at /docs/jndi-resources-howto.html
+  -->
+  <GlobalNamingResources>
+    <!-- Editable user database that can also be used by
+         UserDatabaseRealm to authenticate users
+    -->
+    <Resource name="UserDatabase" auth="Container"
+              type="org.apache.catalina.UserDatabase"
+              description="User database that can be updated and saved"
+              factory="org.apache.catalina.users.MemoryUserDatabaseFactory"
+              pathname="conf/tomcat-users.xml" />
+  
+	<Resource name="java/AdempiereDS" auth="Container"
+						  factory="com.zaxxer.hikari.HikariJNDIFactory"
+						  type="javax.sql.DataSource"
+						  poolName="AdempiereDS"
+						  connectionTimeout="600000"
+						  connectionTestQuery="SELECT Version FROM AD_System"
+						  minimumIdle="20"
+						  maximumPoolSize="150"
+						  idleTimeout="60000"
+						  keepaliveTime="30000"
+						  cachePrepStmts= "true"
+						  prepStmtCacheSize= "250"
+						  prepStmtCacheSqlLimit= "2048"
+						  closeMethod = "close"
+						  socketFactory="com.google.cloud.sql.postgres.SocketFactory"
+						  cloudSqlInstance="INSTANCE_CONNECTION_NAME"
+						  jdbcUrl="@ADEMPIERE_DB_JDBC_URL@"
+						  driverClassName="@ADEMPIERE_CLASS_FORNAME@"
+						  dataSource.serverName="@ADEMPIERE_DB_SERVER@"
+						  dataSource.portNumber="@ADEMPIERE_DB_PORT@"
+						  dataSource.databaseName="@ADEMPIERE_DB_NAME@"
+						  dataSource.user="@ADEMPIERE_DB_USER@"
+						  dataSource.password="@ADEMPIERE_DB_PASSWORD@"/>
+
+	<Resource name="java/AdempiereSRDS" auth="Container"
+						  factory="com.zaxxer.hikari.HikariJNDIFactory"
+						  type="javax.sql.DataSource"
+						  poolName="AdempiereDS"
+						  connectionTimeout="10000"
+						  connectionTestQuery="SELECT Version FROM AD_System"
+						  minimumIdle="11"
+						  maximumPoolSize="20"
+						  idleTimeout="30000"
+						  keepaliveTime="1200"
+						  cachePrepStmts= "true"
+						  prepStmtCacheSize= "250"
+						  prepStmtCacheSqlLimit= "2048"
+						  closeMethod = "close"
+						  socketFactory="com.google.cloud.sql.postgres.SocketFactory"
+						  cloudSqlInstance="INSTANCE_CONNECTION_NAME"
+						  jdbcUrl="@ADEMPIERE_DB_JDBC_URL@"
+						  driverClassName="@ADEMPIERE_CLASS_FORNAME@"
+						  dataSource.serverName="@ADEMPIERE_DB_SERVER@"
+						  dataSource.portNumber="@ADEMPIERE_DB_PORT@"
+						  dataSource.databaseName="@ADEMPIERE_DB_NAME@"
+						  dataSource.user="@ADEMPIERE_DB_USER@"
+						  dataSource.password="@ADEMPIERE_DB_PASSWORD@"/>
+ </GlobalNamingResources>
+
+
+  <!-- A "Service" is a collection of one or more "Connectors" that share
+       a single "Container" Note:  A "Service" is not itself a "Container",
+       so you may not define subcomponents such as "Valves" at this level.
+       Documentation at /docs/config/service.html
+   -->
+  <Service name="Catalina">
+
+    <!--The connectors can use a shared executor, you can define one or more named thread pools-->
+    <!--
+    <Executor name="tomcatThreadPool" namePrefix="catalina-exec-"
+        maxThreads="150" minSpareThreads="4"/>
+    -->
+
+
+    <!-- A "Connector" represents an endpoint by which requests are received
+         and responses are returned. Documentation at :
+         Java HTTP Connector: /docs/config/http.html
+         Java AJP  Connector: /docs/config/ajp.html
+         APR (HTTP/AJP) Connector: /docs/apr.html
+         Define a non-SSL/TLS HTTP/1.1 Connector on port 8080
+    -->
+    <Connector port="8080" protocol="HTTP/1.1"
+               connectionTimeout="20000"
+               redirectPort="8443" />
+    <!-- A "Connector" using the shared thread pool-->
+    <!--
+    <Connector executor="tomcatThreadPool"
+               port="8080" protocol="HTTP/1.1"
+               connectionTimeout="20000"
+               redirectPort="8443" />
+    -->
+    <!-- Define an SSL/TLS HTTP/1.1 Connector on port 8443
+         This connector uses the NIO implementation. The default
+         SSLImplementation will depend on the presence of the APR/native
+         library and the useOpenSSL attribute of the AprLifecycleListener.
+         Either JSSE or OpenSSL style configuration may be used regardless of
+         the SSLImplementation selected. JSSE style configuration is used below.
+    -->
+    <!--
+    <Connector port="8443" protocol="org.apache.coyote.http11.Http11NioProtocol"
+               maxThreads="150" SSLEnabled="true">
+        <SSLHostConfig>
+            <Certificate certificateKeystoreFile="conf/localhost-rsa.jks"
+                         type="RSA" />
+        </SSLHostConfig>
+    </Connector>
+    -->
+    <!-- Define an SSL/TLS HTTP/1.1 Connector on port 8443 with HTTP/2
+         This connector uses the APR/native implementation which always uses
+         OpenSSL for TLS.
+         Either JSSE or OpenSSL style configuration may be used. OpenSSL style
+         configuration is used below.
+    -->
+    <!--
+    <Connector port="8443" protocol="org.apache.coyote.http11.Http11AprProtocol"
+               maxThreads="150" SSLEnabled="true" >
+        <UpgradeProtocol className="org.apache.coyote.http2.Http2Protocol" />
+        <SSLHostConfig>
+            <Certificate certificateKeyFile="conf/localhost-rsa-key.pem"
+                         certificateFile="conf/localhost-rsa-cert.pem"
+                         certificateChainFile="conf/localhost-rsa-chain.pem"
+                         type="RSA" />
+        </SSLHostConfig>
+    </Connector>
+    -->
+
+    <!-- Define an AJP 1.3 Connector on port 8009 -->
+    
+    <Connector port="8009" protocol="AJP/1.3" redirectPort="8443" 
+    	address="0.0.0.0" requiredSecret="servicecatalog"/>
+
+    <!-- An Engine represents the entry point (within Catalina) that processes
+         every request.  The Engine implementation for Tomcat stand alone
+         analyzes the HTTP headers included with the request, and passes them
+         on to the appropriate Host (virtual host).
+         Documentation at /docs/config/engine.html -->
+
+    <!-- You should set jvmRoute to support load-balancing via AJP ie :
+    <Engine name="Catalina" defaultHost="localhost" jvmRoute="jvm1">
+    -->
+    <Engine name="Catalina" defaultHost="localhost">
+
+      <!--For clustering, please take a look at documentation at:
+          /docs/cluster-howto.html  (simple how to)
+          /docs/config/cluster.html (reference documentation) -->
+      <!--
+      <Cluster className="org.apache.catalina.ha.tcp.SimpleTcpCluster"/>
+      -->
+
+      <!-- Use the LockOutRealm to prevent attempts to guess user passwords
+           via a brute-force attack -->
+      <Realm className="org.apache.catalina.realm.LockOutRealm">
+        <!-- This Realm uses the UserDatabase configured in the global JNDI
+             resources under the key "UserDatabase".  Any edits
+             that are performed against this UserDatabase are immediately
+             available for use by the Realm.  -->
+        <Realm className="org.apache.catalina.realm.UserDatabaseRealm"
+               resourceName="UserDatabase"/>
+      </Realm>
+
+      <Host name="localhost"  appBase="webapps"
+            unpackWARs="true" autoDeploy="true">
+
+        <!-- SingleSignOn valve, share authentication between web applications
+             Documentation at: /docs/config/valve.html -->
+        <!--
+        <Valve className="org.apache.catalina.authenticator.SingleSignOn" />
+        -->
+
+        <!-- Access log processes all example.
+             Documentation at: /docs/config/valve.html
+             Note: The pattern used is equivalent to using pattern="common" -->
+        <Valve className="org.apache.catalina.valves.AccessLogValve" directory="logs"
+               prefix="localhost_access_log" suffix=".txt"
+               pattern="%h %l %u %t &quot;%r&quot; %s %b" />
+
+      </Host>
+    </Engine>
+  </Service>
+</Server>

--- a/docker/tomcat/settings/setenv.sh
+++ b/docker/tomcat/settings/setenv.sh
@@ -1,0 +1,40 @@
+#!/bin/sh
+################################################################################
+#  ADempiere Setting script                                                   ##
+#  Setting ADempiere Server                                                   ##
+################################################################################
+
+#Adempiere Application Type
+export ADEMPIERE_APPS_TYPE=tomcat
+
+#Set Database Type
+case $ADEMPIERE_DB_TYPE in 
+	PostgreSQL) 
+		 export ADEMPIERE_CLASS_FORNAME=org.postgresql.Driver
+		 export ADEMPIERE_DB_JDBC_URL="jdbc\:postgresql\://$ADEMPIERE_DB_SERVER\:$ADEMPIERE_DB_PORT/$ADEMPIERE_DB_NAME"
+		 ;;
+	Oracle)
+		 export ADEMPIERE_CLASS_FORNAME=oracle.jdbc.driver.OracleDriver
+		 export ADEMPIERE_DB_JDBC_URL="jdbc:oracle:thin:@$ADEMPIERE_DB_SERVER:$ADEMPIERE_DB_PORT:$ADEMPIERE_DB_NAME"
+		 ;;
+	*)
+		echo "Invalid DataBase Type"
+esac
+
+CATALINA_OPTS="$ADEMPIERE_JAVA_OPTIONS -DPropertyFile=$ADEMPIERE_HOME/Adempiere.properties -DADEMPIERE_HOME=$ADEMPIERE_HOME " 
+
+#Replace values in Adempiere.properties
+sed -i "s|@ADEMPIERE_DB_SERVER@|$ADEMPIERE_DB_SERVER|g" $ADEMPIERE_HOME/Adempiere.properties
+sed -i "s|@ADEMPIERE_DB_PORT@|$ADEMPIERE_DB_PORT|g" $ADEMPIERE_HOME/Adempiere.properties
+sed -i "s|@ADEMPIERE_DB_NAME@|$ADEMPIERE_DB_NAME|g" $ADEMPIERE_HOME/Adempiere.properties
+sed -i "s|@ADEMPIERE_DB_USER@|$ADEMPIERE_DB_USER|g" $ADEMPIERE_HOME/Adempiere.properties
+sed -i "s|@ADEMPIERE_DB_PASSWORD@|$ADEMPIERE_DB_PASSWORD|g" $ADEMPIERE_HOME/Adempiere.properties 
+
+#Replace Values in server.xml
+sed -i "s|@ADEMPIERE_DB_JDBC_URL@|$ADEMPIERE_DB_JDBC_URL|g" $CATALINA_HOME/conf/server.xml
+sed -i "s|@ADEMPIERE_CLASS_FORNAME@|$ADEMPIERE_CLASS_FORNAME|g" $CATALINA_HOME/conf/server.xml
+sed -i "s|@ADEMPIERE_DB_SERVER@|$ADEMPIERE_DB_SERVER|g" $CATALINA_HOME/conf/server.xml
+sed -i "s|@ADEMPIERE_DB_PORT@|$ADEMPIERE_DB_PORT|g" $CATALINA_HOME/conf/server.xml
+sed -i "s|@ADEMPIERE_DB_NAME@|$ADEMPIERE_DB_NAME|g" $CATALINA_HOME/conf/server.xml
+sed -i "s|@ADEMPIERE_DB_USER@|$ADEMPIERE_DB_USER|g" $CATALINA_HOME/conf/server.xml
+sed -i "s|@ADEMPIERE_DB_PASSWORD@|$ADEMPIERE_DB_PASSWORD|g" $CATALINA_HOME/conf/server.xml


### PR DESCRIPTION
# Add Dockerfile for image based on Apache Tomcat

## How to build docker image?

### Clean the project 
```
gradle clean 

```

### Create Release
```
gradle createRelease 

```

### Build With Apache Tomcat 
```
docker build -t adempiere-zk-tomcat -f docker/tomcat/Dockerfile .
```

### Run a Container
```
docker run -d -e "ADEMPIERE_DB_SERVER=database-server" -e "ADEMPIERE_DB_PORT=5432" adempiere-zk-tomcat
```


### Environment variables
- `ADEMPIERE_DB_TYPE`: Database Type (Supported Oracle, PostgreSQL and MariaDB). Default **PostgreSQL**
- `ADEMPIERE_DB_SERVER`: Hostname for PostgreSQL server. Default: **localhost**
- `ADEMPIERE_DB_PORT`: Port used by PostgreSQL server. Default: **5432**
- `ADEMPIERE_DB_NAME`: Database name that Adempiere will use to connect with the database. Default: **adempiere**
- `ADEMPIERE_DB_USER`: Database user that Adempiere will use to connect with the database. Default: **adempiere**
- `ADEMPIERE_DB_PASSWORD`: Database password that Adempiere will use to connect with the database. Default: **adempiere**
- `ADEMPIERE_JAVA_OPTIONS`:  Additional java options to execute application. Default: **-Xms128m -Xmx1024m**
- `ADEMPIERE_HOME`:  Directory of application. Default: **/opt/Adempiere** 