### PR TITLE
Feature/docker images

### DIFF
--- a/docker/compose/.env
+++ b/docker/compose/.env
@@ -1,11 +1,6 @@
 ## Generic Restart
 GENERIC_RESTART="always"
 
-#Main Frontend
-VUE_HOST="http://localhost"
-ZK_HOST="http://localhost:8888"
-IMAGE_SITE_ON_PREMISE="solopcloud/adempiere-site-on-premise:v-0.0.3"
-
 #Database 
 COMPOSE_PROJECT_NAME="adempiere"
 POSTGRES_IMAGE="postgres:13"
@@ -16,4 +11,3 @@ POSTGRES_PORT="5432"
 #Adempire ZK
 ADEMPIERE_ZK_PORT=8888
 ADEMPIERE_NAME="adempiere.zk"
-# docker run -it -d 	--name adempiere-site \	-p 80:80 \ 	-e VUE_HOST="http://localhost:9526" \	-e ZK_HOST="http://localhost:8888" \ solopcloud/adempiere-site-on-premise

--- a/docker/compose/.env
+++ b/docker/compose/.env
@@ -1,0 +1,19 @@
+## Generic Restart
+GENERIC_RESTART="always"
+
+#Main Frontend
+VUE_HOST="http://localhost"
+ZK_HOST="http://localhost:8888"
+IMAGE_SITE_ON_PREMISE="solopcloud/adempiere-site-on-premise:v-0.0.3"
+
+#Database 
+COMPOSE_PROJECT_NAME="adempiere"
+POSTGRES_IMAGE="postgres:13"
+POSTGRES_NAME="postgres.database"
+POSTGRES_PASSWORD="adempiere"
+POSTGRES_PORT="5432"
+
+#Adempire ZK
+ADEMPIERE_ZK_PORT=8888
+ADEMPIERE_NAME="adempiere.zk"
+# docker run -it -d 	--name adempiere-site \	-p 80:80 \ 	-e VUE_HOST="http://localhost:9526" \	-e ZK_HOST="http://localhost:8888" \ solopcloud/adempiere-site-on-premise

--- a/docker/compose/docker-compose.yml
+++ b/docker/compose/docker-compose.yml
@@ -1,0 +1,47 @@
+version: "3.9"
+
+services:
+  adempiere.db:
+    build:
+      context: postgresql/
+      dockerfile: Dockerfile
+    container_name: ${POSTGRES_NAME}
+    restart: ${GENERIC_RESTART}
+    ports:
+      - ${POSTGRES_PORT}
+    volumes:
+      - volume_postgres:/var/lib/postgresql/data
+    healthcheck:
+      test: "bash -c 'printf \"GET / HTTP/1.1\n\n\" > /dev/tcp/127.0.0.1/5432; exit $?;'"
+      interval: 60s
+      retries: 10
+      start_period: 20s
+      timeout: 10s
+    environment:
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+    networks:
+      - adempiere_network
+      
+  adempiere-zk:
+    build:
+      context: ../../
+      dockerfile: docker/jetty/Dockerfile
+    container_name: ${ADEMPIERE_NAME}
+    restart: ${GENERIC_RESTART}
+    ports:
+      - ${ADEMPIERE_ZK_PORT}:8080
+    environment:
+      ADEMPIERE_DB_SERVER: ${POSTGRES_NAME}
+    depends_on:
+      adempiere.db:
+        condition: service_healthy
+    networks:
+      - adempiere_network 
+
+networks:
+  adempiere_network:
+    name: adempiere_network
+
+volumes:
+  volume_postgres:
+    name: volume_postgres

--- a/docker/compose/postgresql/Dockerfile
+++ b/docker/compose/postgresql/Dockerfile
@@ -1,0 +1,8 @@
+FROM postgres:13
+
+ADD https://github.com/adempiere/adempiere/releases/download/3.9.4/Adempiere_394LTS.tar.gz /tmp/Adempiere_394LTS.tar.gz
+
+COPY --chown=1  initdb.sh /docker-entrypoint-initdb.d
+RUN chmod +x /docker-entrypoint-initdb.d/initdb.sh && \
+	tar -xvf /tmp/Adempiere_394LTS.tar.gz Adempiere/data/Adempiere_pg.dmp  -C /tmp/ && \
+	rm /tmp/Adempiere_394LTS.tar.gz

--- a/docker/compose/postgresql/initdb.sh
+++ b/docker/compose/postgresql/initdb.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+if [ "$( psql -U $POSTGRES_USER -tAc "SELECT 1 FROM pg_roles WHERE rolname='adempiere'" )" != '1' ]
+then
+    createuser -U postgres adempiere -dlrs
+    psql -U postgres -tAc "alter user adempiere password 'adempiere';"
+    createdb -U adempiere adempiere
+    psql -U adempiere -d adempiere < Adempiere/data/Adempiere_pg.dmp
+fi


### PR DESCRIPTION
# Add docker compose for run ADempiere ZK with Database

## Requirements
- Free port 8888, or edit variable `ADEMPIERE_ZK_PORT` on `docker/compose/.env` file and set a custom port

## How to run?
- In the `docker/compose/` directory
- run `docker compose up -d`
- Wait some minutes

## Result
[Login in Adempiere](http://localhost:8888/webui)
