### PR TITLE
feat: Update `adempiere-kafka-connector` to `1.4.3`.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -147,7 +147,7 @@ dependencies {
 	// Business Processors (To Task's and Schedulers) (https://central.sonatype.com/artifact/io.github.adempiere/adempiere-business-processors)
 	implementation "${baseGroupId}:adempiere-business-processors:1.1.6"
 	// Engine as Queue (https://central.sonatype.com/artifact/io.github.adempiere/adempiere-kafka-connector)
-	implementation "${baseGroupId}:adempiere-kafka-connector:1.4.1"
+	implementation "${baseGroupId}:adempiere-kafka-connector:1.4.3"
 	// AWS3 Connector to use as File Storage (https://central.sonatype.com/artifact/io.github.adempiere/adempiere-s3-connector)
 	implementation "${baseGroupId}:adempiere-s3-connector:1.0.4"
 	// Third part access using JWT (https://central.sonatype.com/artifact/io.github.adempiere/adempiere-jwt-token)

--- a/build.gradle
+++ b/build.gradle
@@ -146,7 +146,7 @@ dependencies {
 	implementation "${baseGroupId}:adempiere-pos-improvements:1.0.2"
 	// Business Processors (To Task's and Schedulers) (https://central.sonatype.com/artifact/io.github.adempiere/adempiere-business-processors)
 	implementation "${baseGroupId}:adempiere-business-processors:1.1.6"
-	// Engine as Queue (https://central.sonatype.com/artifact/io.github.adempiere/adempiere-kafka-connector)
+	// Engine as Queue (https://github.com/adempiere/adempiere/packages/2207725) (https://central.sonatype.com/artifact/io.github.adempiere/adempiere-kafka-connector)
 	implementation "${baseGroupId}:adempiere-kafka-connector:1.4.3"
 	// AWS3 Connector to use as File Storage (https://central.sonatype.com/artifact/io.github.adempiere/adempiere-s3-connector)
 	implementation "${baseGroupId}:adempiere-s3-connector:1.0.4"


### PR DESCRIPTION
Changelog:
- feat: Overwrite display type on reference to Button fields. by @EdwinBetanc0urt in https://github.com/adempiere/adempiere-kafka-connector/pull/51
- feat: Add Role parameter to Export Dictionary Definition process. by @EdwinBetanc0urt in https://github.com/adempiere/adempiere-kafka-connector/pull/52
- feat: Add process to Export  Role Accesses by client. by @EdwinBetanc0urt in https://github.com/adempiere/adempiere-kafka-connector/pull/53
-  feat: Add process for Export Current Role Accesses of record. by @EdwinBetanc0urt in https://github.com/adempiere/adempiere-kafka-connector/pull/54
- fix: Disable Local Printing app registration as Message Queue type. by @EdwinBetanc0urt in https://github.com/adempiere/adempiere-kafka-connector/pull/49
- feat: Add Jasper Report flag. by @EdwinBetanc0urt in https://github.com/adempiere/adempiere-kafka-connector/pull/50