### PR TITLE
feat: Set `ADEMPIERE_DB_PASSWORD` env with secrets.

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ This project is a java client using swing interface and completely based on grad
 The follow requirements need for run it:
 
 - [Java 11 or higher](https://adoptopenjdk.net/)
-- [Gradle](https://gradle.org/install/)
+- [Gradle 8](https://gradle.org/install/)
 
 ## Runing as development
 ### Clean
@@ -64,6 +64,17 @@ gradle war
 
 You can also run it with `docker compose` for develop enviroment. Note that this is a easy way for start the service with PostgreSQL and middleware.
 
+### Environment variables
+ * `ADEMPIERE_HOME`: Directory where the application will be located. Default: `/opt/Adempiere`.
+ * `ADEMPIERE_DB_TYPE`: Database Type (Supported `Oracle` and `PostgreSQL`). Default `PostgreSQL`.
+ * `ADEMPIERE_DB_SERVER`: Hostname for data base server. Default: `localhost`.
+ * `ADEMPIERE_DB_PORT`: Port used by data base server. Default: `5432`.
+ * `ADEMPIERE_DB_NAME`: Database name that Adempiere-Zk UI will use to connect with the database. Default: `adempiere`.
+ * `ADEMPIERE_DB_USER`: Database user that Adempiere-Zk UI will use to connect with the database. Default: `adempiere`.
+ * `ADEMPIERE_DB_PASSWORD`: Database password that Adempiere-Zk UI will use to connect with the database. Default: `adempiere`. For added security, implement secrets with `ADEMPIERE_DB_PASSWORD_FILE`.
+ * `ADEMPIERE_DB_PASSWORD_FILE`: Database password that Adempiere-Zk UI will use to connect with the database. This overrides `ADEMPIERE_DB_PASSWORD` but if not defined no secrets will be implemented in the password but instead the value of the environment variable will be used.
+ * `ADEMPIERE_JAVA_OPTIONS`: Custom settings to the Java Virtual Machine (JVM). Default: `-Xms64M -Xmx1512M`.
+
 ### Requirements
 
 - [Docker Compose v2.16.0 or later](https://docs.docker.com/compose/install/linux/)
@@ -73,7 +84,7 @@ docker compose version
 Docker Compose version v2.16.0
 ```
 
-## Run it
+### Run it
 
 Just go to `docker-compose` folder and run it
 

--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -1,7 +1,6 @@
-version: "3.9"
 
 services:
-  adempiere.db:
+  adempiere-db:
     build:
       context: postgresql/
       dockerfile: Dockerfile
@@ -18,28 +17,38 @@ services:
       start_period: 20s
       timeout: 10s
     environment:
+      # TODO: Manage with secrets and not with environment variables
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
     networks:
       - adempiere_network
-            
+
   adempiere-zk:
     image: ${ADEMPIERE_ZK_IMAGE}
     container_name: ${ADEMPIERE_NAME}
     restart: ${GENERIC_RESTART}
     ports:
       - ${ADEMPIERE_ZK_PORT}:8080
+    secrets:
+      - adempiere_db_password
     environment:
       ADEMPIERE_DB_SERVER: ${POSTGRES_NAME}
+      ADEMPIERE_DB_PASSWORD_FILE: /run/secrets/adempiere_db_password
     depends_on:
-      adempiere.db:
+      adempiere-db:
         condition: service_healthy
     networks:
-      - adempiere_network 
-      
+      - adempiere_network
+
+
+
 networks:
   adempiere_network:
     name: ${ADEMPIERE_NETWORK}
-    
+
 volumes:
   volume_postgres:
     name: ${POSTGRES_NETWORK}
+
+secrets:
+  adempiere_db_password:
+    file: ./secrets/adempiere_db_password.txt

--- a/docker-compose/secrets/adempiere_db_password.txt
+++ b/docker-compose/secrets/adempiere_db_password.txt
@@ -1,0 +1,1 @@
+adempiere

--- a/docker/jetty/Dockerfile
+++ b/docker/jetty/Dockerfile
@@ -1,4 +1,5 @@
 FROM jetty:10.0.11-jdk11
+
 LABEL manteiner=cparada@erpya.com
 	
 ENV ADEMPIERE_HOME="/opt/Adempiere" \
@@ -8,8 +9,7 @@ ENV ADEMPIERE_HOME="/opt/Adempiere" \
 	ADEMPIERE_DB_TYPE="PostgreSQL" \
 	ADEMPIERE_DB_SERVER="localhost" \
 	ADEMPIERE_DB_NAME="adempiere" \
-	ADEMPIERE_DB_PORT="5432" \
-	ADEMPIERE_APPS_TYPE="jetty"
+	ADEMPIERE_DB_PORT="5432"
 
 COPY --chown=jetty:jetty docker/AdempiereTemplate.properties $ADEMPIERE_HOME/Adempiere.properties
 COPY --chown=jetty:jetty docker/jetty/settings/jetty-ds.xml $JETTY_BASE
@@ -20,5 +20,5 @@ COPY --chown=jetty:jetty docker/jetty/zk-ui/lib/*.jar $JETTY_BASE/lib/ext/
 RUN	rm -R $JETTY_BASE/lib/ext/javaee-api*  && \
 	chmod +x $JETTY_BASE/bin/adempiere.sh  && \
 	/generate-jetty-start.sh
-	
+
 ENTRYPOINT ["bin/adempiere.sh"]

--- a/docker/jetty/settings/adempiere.sh
+++ b/docker/jetty/settings/adempiere.sh
@@ -3,7 +3,15 @@
 #  ADempiere Setting script                                                   ##
 #  Setting ADempiere Server                                                   ##
 ################################################################################
-export EPALE=hola
+
+# Adempiere Application Type
+export ADEMPIERE_APPS_TYPE="jetty"
+
+# Read password from secret file if defined
+if [ -n "$ADEMPIERE_DB_PASSWORD_FILE" ] && [ -f "$ADEMPIERE_DB_PASSWORD_FILE" ]; then
+  export ADEMPIERE_DB_PASSWORD=$(cat "$ADEMPIERE_DB_PASSWORD_FILE")
+fi
+
 #Set Database Type
 case $ADEMPIERE_DB_TYPE in 
 	PostgreSQL) 
@@ -39,4 +47,3 @@ sed -i "s|/usr/local/jetty/etc/jetty-http.xml|/usr/local/jetty/etc/jetty-http.xm
 sed -i "s|-Djetty.base=/var/lib/jetty|-Djetty.base=/var/lib/jetty -DADEMPIERE_HOME=$ADEMPIERE_HOME|g" $JETTY_BASE/jetty.start
 
 /docker-entrypoint.sh
-

--- a/docker/tomcat/Dockerfile
+++ b/docker/tomcat/Dockerfile
@@ -1,4 +1,5 @@
 FROM tomcat:9.0.72-jdk11-temurin
+
 LABEL manteiner=cparada@erpya.com
 	
 ENV ADEMPIERE_HOME="/opt/Adempiere" \
@@ -8,7 +9,7 @@ ENV ADEMPIERE_HOME="/opt/Adempiere" \
 	ADEMPIERE_DB_TYPE="PostgreSQL" \
 	ADEMPIERE_DB_SERVER="localhost" \
 	ADEMPIERE_DB_NAME="adempiere" \
-	ADEMPIERE_DB_PORT="5432" 
+	ADEMPIERE_DB_PORT="5432"
 
 COPY docker/AdempiereTemplate.properties $ADEMPIERE_HOME/Adempiere.properties
 COPY docker/tomcat/settings/*.xml $CATALINA_HOME/conf

--- a/docker/tomcat/settings/setenv.sh
+++ b/docker/tomcat/settings/setenv.sh
@@ -4,8 +4,13 @@
 #  Setting ADempiere Server                                                   ##
 ################################################################################
 
-#Adempiere Application Type
-export ADEMPIERE_APPS_TYPE=tomcat
+# Adempiere Application Type
+export ADEMPIERE_APPS_TYPE="tomcat"
+
+# Read password from secret file if defined
+if [ -n "$ADEMPIERE_DB_PASSWORD_FILE" ] && [ -f "$ADEMPIERE_DB_PASSWORD_FILE" ]; then
+  export ADEMPIERE_DB_PASSWORD=$(cat "$ADEMPIERE_DB_PASSWORD_FILE")
+fi
 
 #Set Database Type
 case $ADEMPIERE_DB_TYPE in 


### PR DESCRIPTION
Add environment `ADEMPIERE_DB_PASSWORD_FILE` to manage password secret file


![imagen](https://github.com/user-attachments/assets/e845db04-3f47-429e-ae06-de94b2440a08)

```log
01:10:04.064 Adempiere.startup: ADempiere(r) test-0.0.3_2025-03-03 - Smart Suite ERP,CRM and SCM - (c) 1999-2023 ADempiere(r) Implementation: test-0.0.3 - Supported by ADempiere community [1]
*** 2025-03-03 01:10:04.071 Adempiere Log (CLogConsole) ***
01:10:04.097 Ini.loadProperties: /opt/Adempiere/Adempiere.properties #34 [1]
-----------> DB_PostgreSQL.lambda$getDataSource$0: Connection Lookup JNDI Datasource for java:comp/env/java/AdempiereDS Hikari Connection Pool [1]
-----------> zkoss.doGet:383: Unknown path info: /comet [20]
CLogFile[/opt/Adempiere/log/2025-03-03_0.log,Level=ALL]
Overwrite jar:file:/tmp/jetty/jetty-0_0_0_0-8080-webui_war-_webui-any-18207940667424953747/webapp/WEB-INF/lib/zkplus.jar!/metainfo/zk/lang-addon.xml
with jar:file:/var/lib/jetty/lib/ext/zkplus.jar!/metainfo/zk/lang-addon.xml
WARNING: Replicate resource: databind
```

![imagen](https://github.com/user-attachments/assets/253d3b6a-7838-4500-bb31-b4d0ad8eab46)

### Additional context
https://docs.docker.com/engine/swarm/secrets/